### PR TITLE
skip init() on boot to fix possible infinite loop

### DIFF
--- a/micropython/modules_py/boot.py
+++ b/micropython/modules_py/boot.py
@@ -1,6 +1,6 @@
 # PicoSystem boot script
 # Runs the PicoSystem init() and launches the launcher if A is held.
-init()
+# init()
 
-if button(A):
-    import launcher  # noqa: F401
+# if button(A):
+#     import launcher  # noqa: F401


### PR DESCRIPTION
I created and saved a `main.py` that called `init()`. This may have caused an infinite loop, so this temporary workaround will comment out the system's `init()` call to hopefully break the loop and allow me to connect the system to Thonny.

Built UF2 under artifacts at: https://github.com/menehune23/picosystem/actions/runs/8761830113